### PR TITLE
fix: git_data_dirs is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use the role add following to the `requirements.yml`:
 ```yaml
 collections:
   - name: adfinis.gitlab
-    version: 1.0.1
+    version: 1.0.3
 ```
 
 ## Roles

--- a/roles/gitlab/templates/gitlab.rb.j2
+++ b/roles/gitlab/templates/gitlab.rb.j2
@@ -32,14 +32,23 @@ gitlab_rails['redis_sentinels_password'] = "{{ gitlab_redis_sentinel_password }}
 gitlab_rails['monitoring_whitelist'] = ["0.0.0.0/0"]
 
 {% if gitlab_use_internal_gitaly %}
-git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })
+gitaly['configuration'] = {
+  storage: [
+    {
+      name: 'default',
+      path: '{{ gitlab_git_data_dir }}',
+    },
+  ],
+}
 {% else %}
 gitaly['enable'] = false
 gitlab_rails['gitaly_token'] = "{{ gitlab_gitaly_token }}"
 gitlab_shell['secret_token'] = "{{ gitlab_secret_token }}"
-git_data_dirs({
-  'default' => { 'gitaly_address' => 'tcp://{{ gitlab_gitaly_instance_ip }}:{{ gitlab_gitaly_instance_port }}' },
-})
+gitlab_rails['repositories_storages'] = {
+  "default" => {
+    "gitaly_address" => "tcp://{{ gitlab_gitaly_instance_ip }}:{{ gitlab_gitaly_instance_port }}"
+  }
+}
 {% endif %}
 
 gitlab_rails['gitlab_email_enabled'] = {{ gitlab_email_enabled }}


### PR DESCRIPTION
As described here:
https://docs.gitlab.com/omnibus/settings/configuration/#migrating-from-git_data_dirs

This configuration option is deprecated. 