### PR TITLE
fix: Gitlab 18.4.0 removes Gitlab::BackgroundMigration.remaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ cython_debug/
 #.idea/
 
 collections/
+
+.ansible/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/adfinis/ansible-collection-gitlab/ansible-lint.yml)
 [![adfinis.gitlab on Ansible Galaxy](https://img.shields.io/badge/collection-adfinis.gitlab-blue)](https://galaxy.ansible.com/ui/repo/published/adfinis/gitlab/)
 
-
 This role deploys GitLab package.
 
 To use the role add following to the `requirements.yml`:
@@ -12,7 +11,7 @@ To use the role add following to the `requirements.yml`:
 ```yaml
 collections:
   - name: adfinis.gitlab
-    version: 1.0.3
+    version: 1.0.4
 ```
 
 ## Roles
@@ -22,6 +21,7 @@ collections:
 Role is based on [HIFIS GitLab role](https://github.com/hifis-net/ansible-collection-toolkit/tree/main/roles/gitlab).
 
 It adds support for:
+
 - nested keys configuration as list e.g. `- key: ["object_store", "enabled"]`
 - deployment of custom pre-receive hooks
 - self-signed keys for test/PoC environments
@@ -52,4 +52,4 @@ Example Playbook:
 
 The Ansible collection `adfinis.gitlab` was written by:
 
-* Adfinis AG | [Website](https://www.adfinis.com/) | [GitHub](https://github.com/adfinis)
+- Adfinis AG | [Website](https://www.adfinis.com/) | [GitHub](https://github.com/adfinis)

--- a/example/group_vars/gitlab/main.yml
+++ b/example/group_vars/gitlab/main.yml
@@ -1,4 +1,4 @@
-gitlab_version: "17.0.1"
+gitlab_version: "18.5.3"
 gitlab_release: "ee.0"
 gitlab_is_primary: "true"
 gitlab_external_url: "https://{{ ansible_host }}"

--- a/roles/gitlab/tasks/install.yml
+++ b/roles/gitlab/tasks/install.yml
@@ -110,7 +110,8 @@
     - name: Wait until all previous background migrations are processed.
       become: true
       ansible.builtin.command:
-        cmd: gitlab-rails runner -e production 'puts Gitlab::BackgroundMigration.remaining'
+        # https://forum.gitlab.com/t/gitlab-18-4-0-removes-gitlab-backgroundmigration-remaining/131336
+        cmd: gitlab-rails runner -e production 'puts Gitlab::Database::BackgroundMigration::BatchedMigration.select{ |m| not m.finished? and not m.finalized? }'
       register: remaining
       until: remaining.stdout == "0"
       retries: 10

--- a/roles/gitlab/tasks/install.yml
+++ b/roles/gitlab/tasks/install.yml
@@ -112,8 +112,8 @@
       ansible.builtin.command:
         # https://forum.gitlab.com/t/gitlab-18-4-0-removes-gitlab-backgroundmigration-remaining/131336
         cmd: gitlab-rails runner -e production 'puts Gitlab::Database::BackgroundMigration::BatchedMigration.select{ |m| not m.finished? and not m.finalized? }'
-      register: remaining
-      until: remaining.stdout == "0"
+      register: gitlab_remaining
+      until: gitlab_remaining.stdout == "0"
       retries: 10
       delay: 10
       check_mode: false

--- a/tests/e2e/kvm/build-vm.sh
+++ b/tests/e2e/kvm/build-vm.sh
@@ -3,9 +3,9 @@
 cd $(dirname "$0")
 
 # check for and download Debian base image if necessary
-test ! -e /var/lib/libvirt/images/debian-12-generic-amd64.qcow2 && \
-wget -c -P /tmp https://cdimage.debian.org/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2 && \
-sudo mv /tmp/debian-12-generic-amd64.qcow2 /var/lib/libvirt/images/debian-12-generic-amd64.qcow2
+test ! -e /var/lib/libvirt/images/debian-13-generic-amd64.qcow2 && \
+wget -c -P /tmp https://cdimage.debian.org/images/cloud/trixies/latest/debian-13-generic-amd64.qcow2 && \
+sudo mv /tmp/debian-13-generic-amd64.qcow2 /var/lib/libvirt/images/debian-13-generic-amd64.qcow2
 
 awk -v key="$(cat id_ed25519.pub)" 'gsub(/<SSH_KEY>/, key)1' cloud-init.cfg.template > cloud-init.cfg
 
@@ -13,7 +13,7 @@ sudo virt-install \
   --name gitlab_e2e_ansible \
   --memory 8192 \
   --vcpus 4 \
-  --disk=size=12,backing_store=/var/lib/libvirt/images/debian-12-generic-amd64.qcow2 \
+  --disk=size=12,backing_store=/var/lib/libvirt/images/debian-13-generic-amd64.qcow2 \
   --cloud-init user-data=./cloud-init.cfg,disable=on \
   --network network=default \
   --osinfo=debian12 \


### PR DESCRIPTION
* ref: https://forum.gitlab.com/t/gitlab-18-4-0-removes-gitlab-backgroundmigration-remaining/131336
* cleanup gitignore
* bump versions
* bump e2e VM from debian 12 to 13
* formatting